### PR TITLE
cherry pick #12 to branch 2.8

### DIFF
--- a/.github/workflows/test-integration-mesh-worker-service.yml
+++ b/.github/workflows/test-integration-mesh-worker-service.yml
@@ -53,7 +53,9 @@ jobs:
         run: mvn clean install -DskipTests
 
       - name: Build pulsar image with mesh-worker-service
-        run: docker build --tag mesh-worker-service-integration-pulsar:latest -f integration-tests/docker/Dockerfile ./
+        run: |
+          PULSAR_IMAGE_TAG=$(mvn -q -Dexec.executable=echo -Dexec.args='${pulsar.version}' --non-recursive exec:exec)
+          docker build --tag mesh-worker-service-integration-pulsar:latest --build-arg PULSAR_IMAGE_TAG="$PULSAR_IMAGE_TAG" -f integration-tests/docker/Dockerfile ./
 
       - name: Deploy k8s cluster env
         uses: nick-invision/retry@v2

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -17,7 +17,8 @@
 # under the License.
 #
 
-FROM streamnative/pulsar:2.8.1.22
+ARG PULSAR_IMAGE_TAG
+FROM streamnative/pulsar:${PULSAR_IMAGE_TAG}
 COPY ./target/mesh-worker-service*.nar /pulsar/mesh-worker-service.nar
 COPY ./integration-tests/docker/connectors.yaml /pulsar/conf/connectors.yaml
 RUN mkdir -p /pulsar-nar

--- a/scripts/set-pulsar-version.sh
+++ b/scripts/set-pulsar-version.sh
@@ -19,4 +19,10 @@ if [[ "x$version" == "x" ]]; then
   exit 1
 fi
 
+OLDVERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${pulsar.version}' --non-recursive exec:exec)
+echo "OLDVERSION=${OLDVERSION}"
 mvn versions:set-property -Dproperty=pulsar.version -DnewVersion=${version}
+
+# bump integration tests
+sed -i.bak -E "s/${OLDVERSION}/${NEW_VERSION}/g" integration-tests/docker/connectors.yaml
+sed -i.bak -E "s/${OLDVERSION}/${NEW_VERSION}/g" .ci/clusters/values_mesh_worker_service.yaml


### PR DESCRIPTION
…on-with-script-for-actions

bump tests versions when set pulsar version
# Conflicts:
#	integration-tests/docker/Dockerfile
#	integration-tests/docker/connectors.yaml