### PR TITLE
update log4j to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <pulsar.version>2.9.0.0-rc-6</pulsar.version>
         <lombok.version>1.18.16</lombok.version>
-        <log4j2.version>2.14.0</log4j2.version>
+        <log4j2.version>2.15.0</log4j2.version>
         <kubernetes-client.version>12.0.1</kubernetes-client.version>
         <license.plugin.version>3.0</license.plugin.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
Update log4j2 version to 2.15.0 , because log4j2 have a RCE zero day.