### PR TITLE
remove dependecies from kubernetes runtime configs

### DIFF
--- a/src/main/java/io/functionmesh/compute/MeshWorker.java
+++ b/src/main/java/io/functionmesh/compute/MeshWorker.java
@@ -25,7 +25,6 @@ import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
-import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.functions.worker.ErrorNotifier;

--- a/src/main/java/io/functionmesh/compute/MeshWorkerService.java
+++ b/src/main/java/io/functionmesh/compute/MeshWorkerService.java
@@ -22,6 +22,7 @@ import io.functionmesh.compute.models.MeshWorkerServiceCustomConfig;
 import io.functionmesh.compute.rest.api.FunctionsImpl;
 import io.functionmesh.compute.rest.api.SinksImpl;
 import io.functionmesh.compute.rest.api.SourcesImpl;
+import io.functionmesh.compute.util.KubernetesUtils;
 import io.functionmesh.compute.worker.MeshConnectorsManager;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
@@ -74,6 +75,7 @@ public class MeshWorkerService implements WorkerService {
     private CustomObjectsApi customObjectsApi;
     private ApiClient apiClient;
     private PulsarAdmin brokerAdmin;
+    @Deprecated
     private KubernetesRuntimeFactoryConfig factoryConfig;
     private MeshWorkerServiceCustomConfig meshWorkerServiceCustomConfig;
 
@@ -192,4 +194,8 @@ public class MeshWorkerService implements WorkerService {
         // to do https://github.com/streamnative/function-mesh/issues/56
     }
 
+    public String getJobNamespace() {
+        String kubernetesJobNamespace = KubernetesUtils.getNamespace(getMeshWorkerServiceCustomConfig(), getFactoryConfig());
+        return kubernetesJobNamespace;
+    }
 }

--- a/src/main/java/io/functionmesh/compute/MeshWorkerService.java
+++ b/src/main/java/io/functionmesh/compute/MeshWorkerService.java
@@ -195,7 +195,6 @@ public class MeshWorkerService implements WorkerService {
     }
 
     public String getJobNamespace() {
-        String kubernetesJobNamespace = KubernetesUtils.getNamespace(getMeshWorkerServiceCustomConfig(), getFactoryConfig());
-        return kubernetesJobNamespace;
+        return KubernetesUtils.getNamespace(getMeshWorkerServiceCustomConfig(), this.getFactoryConfig());
     }
 }

--- a/src/main/java/io/functionmesh/compute/models/MeshWorkerServiceCustomConfig.java
+++ b/src/main/java/io/functionmesh/compute/models/MeshWorkerServiceCustomConfig.java
@@ -173,6 +173,11 @@ public class MeshWorkerServiceCustomConfig {
     )
     protected String jobNamespace;
 
+    @FieldContext(
+            doc = "the directory for dropping extra function dependencies. If it is not absolute path, it is relative to `pulsarRootDir`"
+    )
+    protected String extraFunctionDependenciesDir;
+
     public List<V1alpha1SinkSpecPodVolumes> asV1alpha1SinkSpecPodVolumesList() throws JsonProcessingException {
         ObjectMapper objectMapper = ObjectMapperFactory.getThreadLocal();
         TypeReference<List<V1alpha1SinkSpecPodVolumes>> typeRef

--- a/src/main/java/io/functionmesh/compute/models/MeshWorkerServiceCustomConfig.java
+++ b/src/main/java/io/functionmesh/compute/models/MeshWorkerServiceCustomConfig.java
@@ -168,6 +168,10 @@ public class MeshWorkerServiceCustomConfig {
     )
     protected List<V1alpha1SinkSpecPodInitContainers> sinkInitContainers;
 
+    @FieldContext(
+            doc = "The Kubernetes namespace to run the function instances. It is `default`, if this setting is left to be empty"
+    )
+    protected String jobNamespace;
 
     public List<V1alpha1SinkSpecPodVolumes> asV1alpha1SinkSpecPodVolumesList() throws JsonProcessingException {
         ObjectMapper objectMapper = ObjectMapperFactory.getThreadLocal();

--- a/src/main/java/io/functionmesh/compute/rest/api/FunctionsImpl.java
+++ b/src/main/java/io/functionmesh/compute/rest/api/FunctionsImpl.java
@@ -18,7 +18,6 @@
  */
 package io.functionmesh.compute.rest.api;
 
-import com.google.common.collect.Maps;
 import io.functionmesh.compute.MeshWorkerService;
 import io.functionmesh.compute.functions.models.V1alpha1Function;
 import io.functionmesh.compute.functions.models.V1alpha1FunctionSpecJava;
@@ -61,7 +60,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;

--- a/src/main/java/io/functionmesh/compute/rest/api/FunctionsImpl.java
+++ b/src/main/java/io/functionmesh/compute/rest/api/FunctionsImpl.java
@@ -157,14 +157,13 @@ public class FunctionsImpl extends MeshComponentImpl implements Functions<MeshWo
                 worker()
         );
         // override namespace by configuration file
-        v1alpha1Function.getMetadata().setNamespace(KubernetesUtils.getNamespace(worker().getFactoryConfig()));
-
+        v1alpha1Function.getMetadata().setNamespace(worker().getJobNamespace());
         try {
             this.upsertFunction(tenant, namespace, functionName, functionConfig, v1alpha1Function, clientAuthenticationDataHttps);
             Call call = worker().getCustomObjectsApi().createNamespacedCustomObjectCall(
                     group,
                     version,
-                    KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                    worker().getJobNamespace(),
                     plural,
                     v1alpha1Function,
                     null,
@@ -234,7 +233,7 @@ public class FunctionsImpl extends MeshComponentImpl implements Functions<MeshWo
             Call getCall = worker().getCustomObjectsApi().getNamespacedCustomObjectCall(
                     group,
                     version,
-                    KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                    worker().getJobNamespace(),
                     plural,
                     v1alpha1Function.getMetadata().getName(),
                     null
@@ -245,14 +244,14 @@ public class FunctionsImpl extends MeshComponentImpl implements Functions<MeshWo
                 throw new RestException(Response.Status.NOT_FOUND, "This function resource was not found");
             }
 
-            v1alpha1Function.getMetadata().setNamespace(KubernetesUtils.getNamespace(worker().getFactoryConfig()));
+            v1alpha1Function.getMetadata().setNamespace(worker().getJobNamespace());
             v1alpha1Function.getMetadata().setResourceVersion(oldFn.getMetadata().getResourceVersion());
 
             this.upsertFunction(tenant, namespace, functionName, functionConfig, v1alpha1Function, clientAuthenticationDataHttps);
             Call replaceCall = worker().getCustomObjectsApi().replaceNamespacedCustomObjectCall(
                     group,
                     version,
-                    KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                    worker().getJobNamespace(),
                     plural,
                     v1alpha1Function.getMetadata().getName(),
                     v1alpha1Function,
@@ -287,7 +286,7 @@ public class FunctionsImpl extends MeshComponentImpl implements Functions<MeshWo
             Call call = worker().getCustomObjectsApi().getNamespacedCustomObjectCall(
                     group,
                     version,
-                    KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                    worker().getJobNamespace(),
                     plural,
                     hashName,
                     null
@@ -329,7 +328,7 @@ public class FunctionsImpl extends MeshComponentImpl implements Functions<MeshWo
                 ComponentTypeUtils.toString(componentType));
         try {
             String hashName = CommonUtil.generateObjectName(worker(), tenant, namespace, componentName);
-            String nameSpaceName = KubernetesUtils.getNamespace(worker().getFactoryConfig());
+            String nameSpaceName = worker().getJobNamespace();
             Call call = worker().getCustomObjectsApi().getNamespacedCustomObjectCall(
                     group, version, nameSpaceName,
                     plural, hashName, null);
@@ -611,14 +610,12 @@ public class FunctionsImpl extends MeshComponentImpl implements Functions<MeshWo
                     if (!StringUtils.isEmpty(worker().getWorkerConfig().getBrokerClientAuthenticationPlugin())
                             && !StringUtils.isEmpty(worker().getWorkerConfig().getBrokerClientAuthenticationParameters())) {
                         String authSecretName = KubernetesUtils.upsertSecret(kind.toLowerCase(), "auth",
-                                v1alpha1Function.getSpec().getClusterName(), tenant, namespace, functionName,
-                                worker().getWorkerConfig(), worker().getCoreV1Api(), worker().getFactoryConfig());
+                                v1alpha1Function.getSpec().getClusterName(), tenant, namespace, functionName, worker());
                         v1alpha1Function.getSpec().getPulsar().setAuthSecret(authSecretName);
                     }
                     if (worker().getWorkerConfig().getTlsEnabled()) {
                         String tlsSecretName = KubernetesUtils.upsertSecret(kind.toLowerCase(), "tls",
-                                v1alpha1Function.getSpec().getClusterName(), tenant, namespace, functionName,
-                                worker().getWorkerConfig(), worker().getCoreV1Api(), worker().getFactoryConfig());
+                                v1alpha1Function.getSpec().getClusterName(), tenant, namespace, functionName, worker());
                         v1alpha1Function.getSpec().getPulsar().setTlsSecret(tlsSecretName);
                     }
                     if (!StringUtils.isEmpty(customConfig.getDefaultServiceAccountName())

--- a/src/main/java/io/functionmesh/compute/rest/api/MeshComponentImpl.java
+++ b/src/main/java/io/functionmesh/compute/rest/api/MeshComponentImpl.java
@@ -111,7 +111,7 @@ public abstract class MeshComponentImpl implements Component<MeshWorkerService> 
             Call deleteObjectCall = worker().getCustomObjectsApi().deleteNamespacedCustomObjectCall(
                     group,
                     version,
-                    KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                    worker().getJobNamespace(),
                     plural,
                     hashName,
                     null,
@@ -137,7 +137,7 @@ public abstract class MeshComponentImpl implements Component<MeshWorkerService> 
                                         DigestUtils.sha256Hex(
                                                 KubernetesUtils.getSecretName(
                                                         clusterName, tenant, namespace, componentName))),
-                                KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                                worker().getJobNamespace(),
                                 null,
                                 null,
                                 30,
@@ -157,7 +157,7 @@ public abstract class MeshComponentImpl implements Component<MeshWorkerService> 
                                         DigestUtils.sha256Hex(
                                                 KubernetesUtils.getSecretName(
                                                         clusterName, tenant, namespace, componentName))),
-                                KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                                worker().getJobNamespace(),
                                 null,
                                 null,
                                 30,
@@ -313,7 +313,7 @@ public abstract class MeshComponentImpl implements Component<MeshWorkerService> 
             Call call = worker().getCustomObjectsApi().listNamespacedCustomObjectCall(
                     group,
                     version,
-                    KubernetesUtils.getNamespace(worker().getFactoryConfig()), plural,
+                    worker().getJobNamespace(), plural,
                     "false",
                     null,
                     null,

--- a/src/main/java/io/functionmesh/compute/rest/api/MeshComponentImpl.java
+++ b/src/main/java/io/functionmesh/compute/rest/api/MeshComponentImpl.java
@@ -58,7 +58,6 @@ import static io.functionmesh.compute.util.CommonUtil.COMPONENT_LABEL_CLAIM;
 import static io.functionmesh.compute.util.CommonUtil.getCustomLabelClaimsSelector;
 import static io.functionmesh.compute.util.PackageManagementServiceUtil.getPackageTypeFromComponentType;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.pulsar.functions.proto.Function.FunctionDetails.ComponentType.FUNCTION;
 
 @Slf4j
 public abstract class MeshComponentImpl implements Component<MeshWorkerService> {

--- a/src/main/java/io/functionmesh/compute/rest/api/SinksImpl.java
+++ b/src/main/java/io/functionmesh/compute/rest/api/SinksImpl.java
@@ -18,7 +18,6 @@
  */
 package io.functionmesh.compute.rest.api;
 
-import com.google.common.collect.Maps;
 import io.functionmesh.compute.functions.models.V1alpha1FunctionSpecPodInitContainers;
 import io.functionmesh.compute.models.MeshWorkerServiceCustomConfig;
 import io.functionmesh.compute.sinks.models.V1alpha1Sink;

--- a/src/main/java/io/functionmesh/compute/rest/api/SourcesImpl.java
+++ b/src/main/java/io/functionmesh/compute/rest/api/SourcesImpl.java
@@ -431,11 +431,11 @@ public class SourcesImpl extends MeshComponentImpl implements Sources<MeshWorker
                                     channel[podIndex].shutdown();
                                 }
                                 if (e != null) {
-                                    log.error("Get source {}-{} status from grpc failed from namespace {}, error message: {}",
+                                    log.error("Get source {}-{} status from grpc failed from namespace {}: ",
                                             finalStatefulSetName,
                                             shardId,
                                             nameSpaceName,
-                                            e.getMessage());
+                                            e);
                                     sourceInstanceStatusData.setError(e.getMessage());
                                 } else if (fs != null) {
                                     SourcesUtil.convertFunctionStatusToInstanceStatusData(fs, sourceInstanceStatusData);
@@ -514,8 +514,8 @@ public class SourcesImpl extends MeshComponentImpl implements Sources<MeshWorker
                 }
             }
         } catch (Exception e) {
-            log.error("Get source {} status failed from namespace {}, error message: {}",
-                    componentName, namespace, e.getMessage());
+            log.error("Get source {} status failed from namespace {}: ",
+                    componentName, namespace, e);
         }
 
         return sourceStatus;

--- a/src/main/java/io/functionmesh/compute/rest/api/SourcesImpl.java
+++ b/src/main/java/io/functionmesh/compute/rest/api/SourcesImpl.java
@@ -171,11 +171,11 @@ public class SourcesImpl extends MeshComponentImpl implements Sources<MeshWorker
                         this.meshWorkerServiceSupplier.get().getConnectorsManager(),
                         cluster, worker());
 
-        v1alpha1Source.getMetadata().setNamespace(KubernetesUtils.getNamespace(worker().getFactoryConfig()));
+        v1alpha1Source.getMetadata().setNamespace(worker().getJobNamespace());
         try {
             this.upsertSource(tenant, namespace, sourceName, sourceConfig, v1alpha1Source, clientAuthenticationDataHttps);
             Call call = worker().getCustomObjectsApi().createNamespacedCustomObjectCall(
-                    group, version, KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                    group, version, worker().getJobNamespace(),
                     plural,
                     v1alpha1Source,
                     null,
@@ -243,7 +243,7 @@ public class SourcesImpl extends MeshComponentImpl implements Sources<MeshWorker
             Call getCall = worker().getCustomObjectsApi().getNamespacedCustomObjectCall(
                     group,
                     version,
-                    KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                    worker().getJobNamespace(),
                     plural,
                     v1alpha1Source.getMetadata().getName(),
                     null
@@ -254,13 +254,13 @@ public class SourcesImpl extends MeshComponentImpl implements Sources<MeshWorker
                 throw new RestException(Response.Status.NOT_FOUND, "This source resource was not found");
             }
 
-            v1alpha1Source.getMetadata().setNamespace(KubernetesUtils.getNamespace(worker().getFactoryConfig()));
+            v1alpha1Source.getMetadata().setNamespace(worker().getJobNamespace());
             v1alpha1Source.getMetadata().setResourceVersion(oldRes.getMetadata().getResourceVersion());
             this.upsertSource(tenant, namespace, sourceName, sourceConfig, v1alpha1Source, clientAuthenticationDataHttps);
             Call replaceCall = worker().getCustomObjectsApi().replaceNamespacedCustomObjectCall(
                     group,
                     version,
-                    KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                    worker().getJobNamespace(),
                     plural,
                     v1alpha1Source.getMetadata().getName(),
                     v1alpha1Source,
@@ -291,7 +291,7 @@ public class SourcesImpl extends MeshComponentImpl implements Sources<MeshWorker
 
         try {
             String hashName = CommonUtil.generateObjectName(worker(), tenant, namespace, componentName);
-            String nameSpaceName = KubernetesUtils.getNamespace(worker().getFactoryConfig());
+            String nameSpaceName = worker().getJobNamespace();
             Call call = worker().getCustomObjectsApi().getNamespacedCustomObjectCall(
                     group, version, nameSpaceName,
                     plural, hashName, null);
@@ -544,7 +544,7 @@ public class SourcesImpl extends MeshComponentImpl implements Sources<MeshWorker
             Call call = worker().getCustomObjectsApi().getNamespacedCustomObjectCall(
                     group,
                     version,
-                    KubernetesUtils.getNamespace(worker().getFactoryConfig()),
+                    worker().getJobNamespace(),
                     plural,
                     hashName,
                     null
@@ -617,14 +617,12 @@ public class SourcesImpl extends MeshComponentImpl implements Sources<MeshWorker
                     if (!StringUtils.isEmpty(worker().getWorkerConfig().getBrokerClientAuthenticationPlugin())
                             && !StringUtils.isEmpty(worker().getWorkerConfig().getBrokerClientAuthenticationParameters())) {
                         String authSecretName = KubernetesUtils.upsertSecret(kind.toLowerCase(), "auth",
-                                v1alpha1Source.getSpec().getClusterName(), tenant, namespace, sourceName,
-                                worker().getWorkerConfig(), worker().getCoreV1Api(), worker().getFactoryConfig());
+                                v1alpha1Source.getSpec().getClusterName(), tenant, namespace, sourceName, worker());
                         v1alpha1Source.getSpec().getPulsar().setAuthSecret(authSecretName);
                     }
                     if (worker().getWorkerConfig().getTlsEnabled()) {
                         String tlsSecretName = KubernetesUtils.upsertSecret(kind.toLowerCase(), "tls",
-                                v1alpha1Source.getSpec().getClusterName(), tenant, namespace, sourceName,
-                                worker().getWorkerConfig(), worker().getCoreV1Api(), worker().getFactoryConfig());
+                                v1alpha1Source.getSpec().getClusterName(), tenant, namespace, sourceName, worker());
                         v1alpha1Source.getSpec().getPulsar().setTlsSecret(tlsSecretName);
                     }
                     if (!StringUtils.isEmpty(customConfig.getDefaultServiceAccountName())

--- a/src/main/java/io/functionmesh/compute/rest/api/SourcesImpl.java
+++ b/src/main/java/io/functionmesh/compute/rest/api/SourcesImpl.java
@@ -18,7 +18,6 @@
  */
 package io.functionmesh.compute.rest.api;
 
-import com.google.common.collect.Maps;
 import io.functionmesh.compute.MeshWorkerService;
 import io.functionmesh.compute.models.MeshWorkerServiceCustomConfig;
 import io.functionmesh.compute.sinks.models.V1alpha1SinkSpecPodInitContainers;
@@ -65,7 +64,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;

--- a/src/main/java/io/functionmesh/compute/util/FunctionsUtil.java
+++ b/src/main/java/io/functionmesh/compute/util/FunctionsUtil.java
@@ -70,7 +70,6 @@ import java.util.Map;
 
 import static io.functionmesh.compute.models.SecretRef.PATH_KEY;
 import static io.functionmesh.compute.models.SecretRef.KEY_KEY;
-import static io.functionmesh.compute.util.CommonUtil.DEFAULT_FUNCTION_DOWNLOAD_DIRECTORY;
 import static io.functionmesh.compute.util.CommonUtil.DEFAULT_FUNCTION_EXECUTABLE;
 import static io.functionmesh.compute.util.CommonUtil.buildDownloadPath;
 import static io.functionmesh.compute.util.CommonUtil.getCustomLabelClaims;

--- a/src/main/java/io/functionmesh/compute/util/FunctionsUtil.java
+++ b/src/main/java/io/functionmesh/compute/util/FunctionsUtil.java
@@ -304,6 +304,12 @@ public class FunctionsUtil {
                 } else {
                     extraDependenciesDir = "/pulsar/" + worker.getFactoryConfig().getExtraFunctionDependenciesDir();
                 }
+            } else if (StringUtils.isNotEmpty(customConfig.getExtraFunctionDependenciesDir())) {
+                if (Paths.get(customConfig.getExtraFunctionDependenciesDir()).isAbsolute()) {
+                    extraDependenciesDir = customConfig.getExtraFunctionDependenciesDir();
+                } else {
+                    extraDependenciesDir = "/pulsar/" + customConfig.getExtraFunctionDependenciesDir();
+                }
             } else {
                 extraDependenciesDir = "/pulsar/instances/deps";
             }

--- a/src/main/java/io/functionmesh/compute/util/FunctionsUtil.java
+++ b/src/main/java/io/functionmesh/compute/util/FunctionsUtil.java
@@ -298,7 +298,7 @@ public class FunctionsUtil {
                 v1alpha1FunctionSpecJava.setJarLocation(functionPkgUrl);
             }
             String extraDependenciesDir = "";
-            if (StringUtils.isNotEmpty(worker.getFactoryConfig().getExtraFunctionDependenciesDir())) {
+            if (worker.getFactoryConfig() != null && StringUtils.isNotEmpty(worker.getFactoryConfig().getExtraFunctionDependenciesDir())) {
                 if (Paths.get(worker.getFactoryConfig().getExtraFunctionDependenciesDir()).isAbsolute()) {
                     extraDependenciesDir = worker.getFactoryConfig().getExtraFunctionDependenciesDir();
                 } else {

--- a/src/main/java/io/functionmesh/compute/util/SinksUtil.java
+++ b/src/main/java/io/functionmesh/compute/util/SinksUtil.java
@@ -121,7 +121,7 @@ public class SinksUtil {
 
         V1alpha1SinkSpecJava v1alpha1SinkSpecJava = new V1alpha1SinkSpecJava();
         String extraDependenciesDir = "";
-        if (StringUtils.isNotEmpty(worker.getFactoryConfig().getExtraFunctionDependenciesDir())) {
+        if (worker.getFactoryConfig() != null && StringUtils.isNotEmpty(worker.getFactoryConfig().getExtraFunctionDependenciesDir())) {
             if (Paths.get(worker.getFactoryConfig().getExtraFunctionDependenciesDir()).isAbsolute()) {
                 extraDependenciesDir = worker.getFactoryConfig().getExtraFunctionDependenciesDir();
             } else {

--- a/src/main/java/io/functionmesh/compute/util/SinksUtil.java
+++ b/src/main/java/io/functionmesh/compute/util/SinksUtil.java
@@ -35,6 +35,7 @@ import io.functionmesh.compute.sinks.models.V1alpha1SinkSpecPodResources;
 import io.functionmesh.compute.sinks.models.V1alpha1SinkSpecSecretsMap;
 import io.functionmesh.compute.worker.MeshConnectorsManager;
 import io.kubernetes.client.custom.Quantity;
+import java.nio.file.Paths;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
@@ -119,6 +120,24 @@ public class SinksUtil {
         v1alpha1SinkSpec.setReplicas(parallelism);
 
         V1alpha1SinkSpecJava v1alpha1SinkSpecJava = new V1alpha1SinkSpecJava();
+        String extraDependenciesDir = "";
+        if (StringUtils.isNotEmpty(worker.getFactoryConfig().getExtraFunctionDependenciesDir())) {
+            if (Paths.get(worker.getFactoryConfig().getExtraFunctionDependenciesDir()).isAbsolute()) {
+                extraDependenciesDir = worker.getFactoryConfig().getExtraFunctionDependenciesDir();
+            } else {
+                extraDependenciesDir = "/pulsar/" + worker.getFactoryConfig().getExtraFunctionDependenciesDir();
+            }
+        } else if (StringUtils.isNotEmpty(customConfig.getExtraFunctionDependenciesDir())) {
+            if (Paths.get(customConfig.getExtraFunctionDependenciesDir()).isAbsolute()) {
+                extraDependenciesDir = customConfig.getExtraFunctionDependenciesDir();
+            } else {
+                extraDependenciesDir = "/pulsar/" + customConfig.getExtraFunctionDependenciesDir();
+            }
+        } else {
+            extraDependenciesDir = "/pulsar/instances/deps";
+        }
+        v1alpha1SinkSpecJava.setExtraDependenciesDir(extraDependenciesDir);
+
         if (connectorsManager != null && archive.startsWith(BUILTIN)) {
             String connectorType = archive.replaceFirst("^builtin://", "");
             FunctionMeshConnectorDefinition definition = connectorsManager.getConnectorDefinition(connectorType);

--- a/src/main/java/io/functionmesh/compute/util/SourcesUtil.java
+++ b/src/main/java/io/functionmesh/compute/util/SourcesUtil.java
@@ -35,6 +35,7 @@ import io.functionmesh.compute.sources.models.V1alpha1SourceSpecPulsar;
 import io.functionmesh.compute.sources.models.V1alpha1SourceSpecSecretsMap;
 import io.functionmesh.compute.worker.MeshConnectorsManager;
 import io.kubernetes.client.custom.Quantity;
+import java.nio.file.Paths;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
@@ -114,6 +115,23 @@ public class SourcesUtil {
         v1alpha1SourceSpec.setClassName(sourceConfig.getClassName());
 
         V1alpha1SourceSpecJava v1alpha1SourceSpecJava = new V1alpha1SourceSpecJava();
+        String extraDependenciesDir = "";
+        if (StringUtils.isNotEmpty(worker.getFactoryConfig().getExtraFunctionDependenciesDir())) {
+            if (Paths.get(worker.getFactoryConfig().getExtraFunctionDependenciesDir()).isAbsolute()) {
+                extraDependenciesDir = worker.getFactoryConfig().getExtraFunctionDependenciesDir();
+            } else {
+                extraDependenciesDir = "/pulsar/" + worker.getFactoryConfig().getExtraFunctionDependenciesDir();
+            }
+        } else if (StringUtils.isNotEmpty(customConfig.getExtraFunctionDependenciesDir())) {
+            if (Paths.get(customConfig.getExtraFunctionDependenciesDir()).isAbsolute()) {
+                extraDependenciesDir = customConfig.getExtraFunctionDependenciesDir();
+            } else {
+                extraDependenciesDir = "/pulsar/" + customConfig.getExtraFunctionDependenciesDir();
+            }
+        } else {
+            extraDependenciesDir = "/pulsar/instances/deps";
+        }
+        v1alpha1SourceSpecJava.setExtraDependenciesDir(extraDependenciesDir);
         if (connectorsManager != null && archive.startsWith(BUILTIN)) {
             String connectorType = archive.replaceFirst("^builtin://", "");
             FunctionMeshConnectorDefinition definition = connectorsManager.getConnectorDefinition(connectorType);

--- a/src/main/java/io/functionmesh/compute/util/SourcesUtil.java
+++ b/src/main/java/io/functionmesh/compute/util/SourcesUtil.java
@@ -116,7 +116,7 @@ public class SourcesUtil {
 
         V1alpha1SourceSpecJava v1alpha1SourceSpecJava = new V1alpha1SourceSpecJava();
         String extraDependenciesDir = "";
-        if (StringUtils.isNotEmpty(worker.getFactoryConfig().getExtraFunctionDependenciesDir())) {
+        if (worker.getFactoryConfig() != null && StringUtils.isNotEmpty(worker.getFactoryConfig().getExtraFunctionDependenciesDir())) {
             if (Paths.get(worker.getFactoryConfig().getExtraFunctionDependenciesDir()).isAbsolute()) {
                 extraDependenciesDir = worker.getFactoryConfig().getExtraFunctionDependenciesDir();
             } else {

--- a/src/test/java/io/functionmesh/compute/rest/api/FunctionsImplTest.java
+++ b/src/test/java/io/functionmesh/compute/rest/api/FunctionsImplTest.java
@@ -200,17 +200,11 @@ public class FunctionsImplTest {
         String tenant = "public";
         String namespace = "default";
         String name = "test";
-        String group = "compute.functionmesh.io";
-        String plural = "functions";
-        String version = "v1alpha1";
         String hashName = CommonUtil.generateObjectName(meshWorkerService, tenant, namespace, name);
         String jobName = CommonUtil.makeJobName(name, CommonUtil.COMPONENT_SINK);
 
         PowerMockito.when(meshWorkerService.getCustomObjectsApi()
-                .getNamespacedCustomObjectCall(
-                        group, version, namespace, plural,
-                        CommonUtil.createObjectName("test-pulsar", tenant, namespace, name),
-                        null)).thenReturn(call);
+                .getNamespacedCustomObjectCall(any(), any(), any(), any(), any(), any())).thenReturn(call);
         PowerMockito.when(call.execute()).thenReturn(response);
         PowerMockito.when(response.isSuccessful()).thenReturn(true);
         PowerMockito.when(response.body()).thenReturn(responseBody);
@@ -377,15 +371,15 @@ public class FunctionsImplTest {
         v1alpha1Function.getMetadata().setLabels(customLabels);
         PowerMockito.when(meshWorkerService.getCustomObjectsApi()
                 .createNamespacedCustomObjectCall(
-                        group,
-                        version,
-                        KubernetesUtils.getNamespace(),
-                        plural,
-                        v1alpha1Function,
-                        null,
-                        null,
-                        null,
-                        null
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any()
                 )).thenReturn(call);
         PowerMockito.when(call.execute()).thenReturn(response);
         PowerMockito.when(response.isSuccessful()).thenReturn(true);
@@ -516,10 +510,6 @@ public class FunctionsImplTest {
         String tenant = "public";
         String namespace = "default";
         String functionName = "word-count";
-        String group = "compute.functionmesh.io";
-        String plural = "functions";
-        String version = "v1alpha1";
-        String kind = "Function";
 
         MeshWorkerService meshWorkerService = PowerMockito.mock(MeshWorkerService.class);
         Supplier<MeshWorkerService> meshWorkerServiceSupplier = () -> meshWorkerService;
@@ -562,14 +552,7 @@ public class FunctionsImplTest {
         PowerMockito.when(apiClient.getJSON()).thenReturn(json);
 
         PowerMockito.when(meshWorkerService.getCustomObjectsApi()
-                .getNamespacedCustomObjectCall(
-                        group,
-                        version,
-                        namespace,
-                        plural,
-                        "word-count-640ae9e6",
-                        null
-                )).thenReturn(getCall);
+                .getNamespacedCustomObjectCall(any(), any(), any(), any(), any(), any())).thenReturn(getCall);
 
         MeshWorkerServiceCustomConfig meshWorkerServiceCustomConfig = PowerMockito.mock(MeshWorkerServiceCustomConfig.class);
         PowerMockito.when(meshWorkerServiceCustomConfig.isUploadEnabled()).thenReturn(true);
@@ -683,37 +666,34 @@ public class FunctionsImplTest {
         String tenant = "public";
         String namespace = "default";
         String functionName = "word-count";
-        String group = "compute.functionmesh.io";
-        String plural = "functions";
-        String version = "v1alpha1";
 
         Response functionInfoResponse = PowerMockito.mock(Response.class);
         Call functionInfoCall = PowerMockito.mock(Call.class);
         PowerMockito.when(meshWorkerService.getCustomObjectsApi()
                 .getNamespacedCustomObjectCall(
-                        group,
-                        version,
-                        namespace,
-                        plural,
-                        functionName,
-                        null)).thenReturn(functionInfoCall);
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any())).thenReturn(functionInfoCall);
         PowerMockito.when(functionInfoCall.execute()).thenReturn(functionInfoResponse);
         PowerMockito.when(functionInfoResponse.isSuccessful()).thenReturn(true);
         PowerMockito.when(functionInfoResponse.body()).thenReturn(responseBody);
 
         PowerMockito.when(meshWorkerService.getCustomObjectsApi()
                 .deleteNamespacedCustomObjectCall(
-                        group,
-                        version,
-                        namespace,
-                        plural,
-                        "word-count-640ae9e6",
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any()
                 )).thenReturn(call);
         PowerMockito.when(call.execute()).thenReturn(response);
         PowerMockito.when(response.isSuccessful()).thenReturn(true);
@@ -841,18 +821,15 @@ public class FunctionsImplTest {
         String tenant = "public";
         String namespace = "default";
         String functionName = "word-count";
-        String group = "compute.functionmesh.io";
-        String plural = "functions";
-        String version = "v1alpha1";
 
         PowerMockito.when(meshWorkerService.getCustomObjectsApi()
                 .getNamespacedCustomObjectCall(
-                        group,
-                        version,
-                        namespace,
-                        plural,
-                        CommonUtil.createObjectName("test-pulsar", tenant, namespace, functionName),
-                        null
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any()
                 )).thenReturn(call);
         PowerMockito.when(call.execute()).thenReturn(response);
         PowerMockito.when(response.isSuccessful()).thenReturn(true);

--- a/src/test/java/io/functionmesh/compute/rest/api/SinksImpTest.java
+++ b/src/test/java/io/functionmesh/compute/rest/api/SinksImpTest.java
@@ -266,15 +266,15 @@ public class SinksImpTest {
                 meshWorkerService
                                 .getCustomObjectsApi()
                                 .createNamespacedCustomObjectCall(
-                                        group,
-                                        version,
-                                        KubernetesUtils.getNamespace(),
-                                        plural,
-                                        v1alpha1Sink,
-                                        null,
-                                        null,
-                                        null,
-                                        null))
+                                        any(),
+                                        any(),
+                                        any(),
+                                        any(),
+                                        any(),
+                                        any(),
+                                        any(),
+                                        any(),
+                                        any()))
                 .thenReturn(call);
         PowerMockito.when(call.execute()).thenReturn(response);
         PowerMockito.when(response.isSuccessful()).thenReturn(true);
@@ -468,9 +468,7 @@ public class SinksImpTest {
         PowerMockito.when(apiClient.getJSON()).thenReturn(json);
 
         PowerMockito.when(
-                customObjectsApi
-                        .getNamespacedCustomObjectCall(
-                                group, version, namespace, plural, "sink-es-sample-e84d93a8", null))
+                customObjectsApi.getNamespacedCustomObjectCall(any(), any(), any(), any(), any(), any()))
                 .thenReturn(getCall);
 
         Call replaceCall = PowerMockito.mock(Call.class);
@@ -619,9 +617,7 @@ public class SinksImpTest {
         PowerMockito.when(
                 meshWorkerService
                         .getCustomObjectsApi()
-                        .getNamespacedCustomObjectCall(
-                                group, version, namespace, plural,
-                                CommonUtil.createObjectName("test-pulsar", tenant, namespace, componentName), null))
+                        .getNamespacedCustomObjectCall(any(), any(), any(), any(), any(), any()))
                 .thenReturn(call);
         PowerMockito.when(call.execute()).thenReturn(response);
         PowerMockito.when(response.isSuccessful()).thenReturn(true);
@@ -632,7 +628,7 @@ public class SinksImpTest {
         PowerMockito.when(apiClient.getJSON()).thenReturn(json);
 
         V1StatefulSet v1StatefulSet = PowerMockito.mock(V1StatefulSet.class);
-        PowerMockito.when(appsV1Api.readNamespacedStatefulSet(jobName, namespace, null, null, null)).thenReturn(v1StatefulSet);
+        PowerMockito.when(appsV1Api.readNamespacedStatefulSet(any(), any(), any(), any(), any())).thenReturn(v1StatefulSet);
 
         V1ObjectMeta v1StatefulSetV1ObjectMeta = PowerMockito.mock(V1ObjectMeta.class);
         PowerMockito.when(v1StatefulSet.getMetadata()).thenReturn(v1StatefulSetV1ObjectMeta);
@@ -782,9 +778,7 @@ public class SinksImpTest {
         PowerMockito.when(
                 meshWorkerService
                         .getCustomObjectsApi()
-                        .getNamespacedCustomObjectCall(
-                                group, version, namespace, plural,
-                                CommonUtil.createObjectName("test-pulsar", tenant, namespace, componentName), null))
+                        .getNamespacedCustomObjectCall(any(), any(), any(), any(), any(), any()))
                 .thenReturn(call);
         PowerMockito.when(call.execute()).thenReturn(response);
         PowerMockito.when(response.isSuccessful()).thenReturn(true);

--- a/src/test/java/io/functionmesh/compute/rest/api/SourcesImpTest.java
+++ b/src/test/java/io/functionmesh/compute/rest/api/SourcesImpTest.java
@@ -491,8 +491,7 @@ public class SourcesImpTest {
         PowerMockito.when(
                 meshWorkerService
                         .getCustomObjectsApi()
-                        .getNamespacedCustomObjectCall(
-                                group, version, namespace, plural, "source-mongodb-sample-d1dc115a", null))
+                        .getNamespacedCustomObjectCall(any(), any(), any(), any(), any(), any()))
                 .thenReturn(getCall);
 
         PowerMockito.when(
@@ -629,9 +628,6 @@ public class SourcesImpTest {
         ResponseBody responseBody = PowerMockito.mock(RealResponseBody.class);
         ApiClient apiClient = PowerMockito.mock(ApiClient.class);
 
-        String group = "compute.functionmesh.io";
-        String plural = "sources";
-        String version = "v1alpha1";
         String tenant = "public";
         String namespace = "default";
         String componentName = "source-sample";
@@ -642,10 +638,7 @@ public class SourcesImpTest {
         PowerMockito.when(
                 meshWorkerService
                         .getCustomObjectsApi()
-                        .getNamespacedCustomObjectCall(
-                                group, version, namespace, plural,
-                                CommonUtil.createObjectName("test-pulsar", tenant, namespace, componentName),
-                                null))
+                        .getNamespacedCustomObjectCall(any(), any(), any(), any(), any(), any()))
                 .thenReturn(call);
         PowerMockito.when(call.execute()).thenReturn(response);
         PowerMockito.when(response.isSuccessful()).thenReturn(true);
@@ -656,7 +649,7 @@ public class SourcesImpTest {
         PowerMockito.when(apiClient.getJSON()).thenReturn(json);
 
         V1StatefulSet v1StatefulSet = PowerMockito.mock(V1StatefulSet.class);
-        PowerMockito.when(appsV1Api.readNamespacedStatefulSet(jobName, namespace, null, null, null)).thenReturn(v1StatefulSet);
+        PowerMockito.when(appsV1Api.readNamespacedStatefulSet(any(), any(), any(), any(), any())).thenReturn(v1StatefulSet);
         V1ObjectMeta v1StatefulSetV1ObjectMeta = PowerMockito.mock(V1ObjectMeta.class);
         PowerMockito.when(v1StatefulSet.getMetadata()).thenReturn(v1StatefulSetV1ObjectMeta);
         V1StatefulSetSpec v1StatefulSetSpec = PowerMockito.mock(V1StatefulSetSpec.class);
@@ -803,9 +796,6 @@ public class SourcesImpTest {
         ResponseBody responseBody = PowerMockito.mock(RealResponseBody.class);
         ApiClient apiClient = PowerMockito.mock(ApiClient.class);
 
-        String group = "compute.functionmesh.io";
-        String plural = "sources";
-        String version = "v1alpha1";
         String tenant = "public";
         String namespace = "default";
         String componentName = "source-mongodb-sample";
@@ -813,9 +803,7 @@ public class SourcesImpTest {
         PowerMockito.when(
                 meshWorkerService
                         .getCustomObjectsApi()
-                        .getNamespacedCustomObjectCall(
-                                group, version, namespace, plural,
-                                CommonUtil.createObjectName("test-pulsar", tenant, namespace, componentName), null))
+                        .getNamespacedCustomObjectCall(any(), any(), any(), any(), any(), any()))
                 .thenReturn(call);
         PowerMockito.when(call.execute()).thenReturn(response);
         PowerMockito.when(response.isSuccessful()).thenReturn(true);


### PR DESCRIPTION
fix https://github.com/streamnative/function-mesh-worker-service/issues/170

- add `jobNamespace` in `MeshWorkerServiceCustomConfig`
- add `extraFunctionDependenciesDir` in `MeshWorkerServiceCustomConfig`
- deprecated `KubernetesRuntimeFactoryConfig`
- use configs from `MeshWorkerServiceCustomConfig`
- backward compatible 