### PR TITLE
change docker registry from docker.pkg.github.com to ghcr.io

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ secrets.IMAGE_GITHUB_USERNAME }}
           password: ${{ secrets.IMAGE_GITHUB_TOKEN }}
 

--- a/.github/workflows/test-integration-mesh-worker-service.yml
+++ b/.github/workflows/test-integration-mesh-worker-service.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Login to GitHub Packages Docker Registry
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: tuteng
           password: ${{ secrets.IMAGE_GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ docker run \
   -v "$(pwd)":"$(pwd)" \
   -ti \
   --network host \
-  ghcr.io/kubernetes-client/java/crd-model-gen:v1.0.3 \
+  ghcr.io/kubernetes-client/java/crd-model-gen:v1.0.4 \
   /generate.sh \
   -u $LOCAL_MANIFEST_FILE \
   -n io.functionmesh.compute \

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ docker run \
   -v "$(pwd)":"$(pwd)" \
   -ti \
   --network host \
-  docker.pkg.github.com/kubernetes-client/java/crd-model-gen:v1.0.3 \
+  ghcr.io/kubernetes-client/java/crd-model-gen:v1.0.3 \
   /generate.sh \
   -u $LOCAL_MANIFEST_FILE \
   -n io.functionmesh.compute \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ sudo wget https://github.com/mikefarah/yq/releases/download/v4.6.0/yq_linux_amd6
 sudo chmod +x /usr/bin/yq
 yq --help
 
-docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" docker.pkg.github.com
+docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" ghcr.io
 
 source ./scripts/generate-crd.sh
 pushd $HOMEDIR

--- a/scripts/crd-model-gen/Dockerfile
+++ b/scripts/crd-model-gen/Dockerfile
@@ -17,6 +17,6 @@
 # under the License.
 #
 
-FROM docker.pkg.github.com/kubernetes-client/java/crd-model-gen:v1.0.4
+FROM ghcr.io/kubernetes-client/java/crd-model-gen:v1.0.4
 RUN sed -i 's/kind create cluster/\kind create cluster --image=kindest\/node:v1.17.17/' /generate.sh
 #RUN sed -i 's/kubectl apply/\kubectl apply --validate=false/' /generate.sh

--- a/scripts/generate-crd.sh
+++ b/scripts/generate-crd.sh
@@ -43,7 +43,7 @@ yq eval "del(.spec.versions.[].schema.openAPIV3Schema.x-kubernetes-preserve-unkn
 yq eval "del(.spec.versions.[].schema.openAPIV3Schema.x-kubernetes-preserve-unknown-fields)" -i $CRD_SOURCES_FILE
 yq eval "del(.spec.versions.[].schema.openAPIV3Schema.x-kubernetes-preserve-unknown-fields)" -i $CRD_SINKS_FILE
 
-DEFAULT_IMAGE_NAME=docker.pkg.github.com/kubernetes-client/java/crd-model-gen
+DEFAULT_IMAGE_NAME=ghcr.io/kubernetes-client/java/crd-model-gen
 DEFAULT_IMAGE_TAG=v1.0.4
 IMAGE_NAME=${IMAGE_NAME:=$DEFAULT_IMAGE_NAME}
 IMAGE_TAG=${IMAGE_TAG:=$DEFAULT_IMAGE_TAG}


### PR DESCRIPTION
### Motivation
Registry Change: [Migrating to the Container registry from the Docker registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry)
Depend on images: [kubernetes-client/java/crd-model-gen](https://github.com/kubernetes-client/java/pkgs/container/java%2Fcrd-model-gen/7116194?tag=v1.0.4) was migrated to ghcr.io

### Modifications
Change registry from docker.pkg.github.com to ghcr.io：

- modify README.md

- modify build.sh & generate-crd.sh & crd-model-gen/Dockerfile in scripts 

- modify project.yml & test-integration-mesh-worker-service.yml in .github/workflows

### Verifying this change

- [x]  Make sure that the change passes the CI checks.

This change is a trivial rework/code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  tiny fix
  
- [x] `doc` 
  
  (If this PR contains doc changes)