### PR TITLE
Fix docker registry ghcr.io login

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ sudo wget https://github.com/mikefarah/yq/releases/download/v4.6.0/yq_linux_amd6
 sudo chmod +x /usr/bin/yq
 yq --help
 
-docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" ghcr.io
+docker login -u="${GITHUB_USERNAME}" -p="${GITHUB_TOKEN}" ghcr.io
 
 source ./scripts/generate-crd.sh
 pushd $HOMEDIR


### PR DESCRIPTION
## Motivation

Since we have migrated the docker registry to ghcr.io  https://github.com/streamnative/function-mesh-worker-service/pull/290 , we need to log in with GitHub token.

https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry